### PR TITLE
Turn off fail fast

### DIFF
--- a/.github/workflows/main_simple.yaml
+++ b/.github/workflows/main_simple.yaml
@@ -50,6 +50,7 @@ jobs:
     strategy:
       matrix:
         flows: ${{ fromJson(needs.changes.outputs.prefect_flows) }}
+      fail-fast: false
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
When fail fast is on, any errors that occur when deploying a flow result in all other flows being deployed cancelling.

When a second commit is pushed fixing the previous error, the cancelled flows aren't deployed as they no longer have “new” code in the recent commit. 

By setting `fail-fast: false` it will stop the auto cancelling behaviour and allow flows to be deployed irrespective of another failing.

----- 

On a side note, had not used matrix before in a GitHub action until using your template. Super helpful!!! Thank you for the tip :) 