### PR TITLE
Fix reference to project in GHA workflow

### DIFF
--- a/.github/workflows/ecs_prefect_agent.yml
+++ b/.github/workflows/ecs_prefect_agent.yml
@@ -187,8 +187,8 @@ jobs:
           cpu_ = "${{ github.event.inputs.cpu }}"
           memory_ = "${{ github.event.inputs.memory }}"
           aws_acc_id = "$AWS_ACCOUNT_ID"
-          exec_role = f"arn:aws:iam::{aws_acc_id}:role/dataflowops_ecs_execution_role"
-          task_role = f"arn:aws:iam::{aws_acc_id}:role/dataflowops_ecs_task_role"
+          exec_role = f"arn:aws:iam::{aws_acc_id}:role/$PROJECT_ecs_execution_role"
+          task_role = f"arn:aws:iam::{aws_acc_id}:role/$PROJECT_ecs_task_role"
           
           aws_creds = AwsCredentials(aws_access_key_id=id_, aws_secret_access_key=key_)
           aws_creds.save(block_, overwrite=True)


### PR DESCRIPTION
Hey,

tnx for the blog post and this template repo

I deployed it myself with a different project name and found out that exec_role and task_role in ECSTask infra block need to be referenced to the actual project name to match the CloudFormation template.

https://github.com/anna-geller/dataflow-ops/blob/main/infrastructure/ecs_cluster_prefect_agent.yml#L98
https://github.com/anna-geller/dataflow-ops/blob/main/infrastructure/ecs_cluster_prefect_agent.yml#L124

Thank you :sun_with_face: 